### PR TITLE
Add patrol waves, Black Box mission, new stratagems, terrain & weapon system overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
                 <h3>ICBM LAUNCH</h3>
                 <p>Secure the silo. Manual terminal input required.</p>
             </button>
+            <button class="selectable-card" id="miss-blackbox" type="button" data-mission="blackbox">
+                <h3>BLACK BOX RETRIEVAL</h3>
+                <p>Recover 3 data cores from outposts and upload them at the relay uplink.</p>
+            </button>
         </div>
         <button id="mission-next-btn" disabled>CONFIRM MISSION</button>
     </div>
@@ -77,6 +81,7 @@
 
                 <div style="display: flex; justify-content: space-between; margin-top: 8px;"><span>AMMO</span><span id="ammo-text">30/30</span></div>
                 <div class="bar-container"><div id="ammo-fill" class="bar-fill" style="background: var(--ui-yellow);"></div></div>
+                <div id="reserve-text" style="margin-top:6px; font-size:0.72rem; color:#d1d5db;">PRIMARY [1] / SUPPORT [2]</div>
                 <div id="reload-indicator" style="color: var(--ui-red); font-size: 0.7rem; font-weight: bold; height: 1.2em;"></div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,20 @@
         <button id="deploy-btn" disabled>PREPARE FOR DROP</button>
     </div>
 
+    <div id="mission-complete-screen" class="overlay-screen hidden">
+        <h1 style="color: var(--ui-yellow); letter-spacing: 4px;">MISSION COMPLETE</h1>
+        <div class="stats-box" style="max-width:460px; margin:0 auto 20px auto; text-align:left;">
+            <div>MISSION: <span id="mc-mission">-</span></div>
+            <div>TIME: <span id="mc-time">00:00</span></div>
+            <div>KILLS: <span id="mc-kills">0</span></div>
+            <div>OBJECTIVES DONE: <span id="mc-objectives">0</span></div>
+            <div>STRATAGEMS USED: <span id="mc-stratagems">0</span></div>
+            <div>BUG HOLES SEALED: <span id="mc-holes">0</span></div>
+            <div>SCORE: <span id="mc-score">0</span></div>
+        </div>
+        <button id="back-to-menu-btn" type="button">RETURN TO MENU</button>
+    </div>
+
     <div id="ui-layer">
         <div style="display: flex; justify-content: space-between; pointer-events: none;">
             <div class="stats-box">

--- a/main.js
+++ b/main.js
@@ -153,7 +153,7 @@ function startDeployment() {
         extracted: false,
         extraction: {
             x: 0, y: 0, radius: 120, stage: 'LOCKED', defendTimer: 0,
-            code: getRandomCode(4)
+            code: getRandomCode(8)
         },
         icbm: selectedMissionId === 'icbm'
             ? {
@@ -162,8 +162,8 @@ function startDeployment() {
                 silo: null,
                 openingTimer: 0,
                 countdown: 0,
-                armCode: getRandomCode(3),
-                launchCode: getRandomCode(6)
+                armCode: getRandomCode(6),
+                launchCode: getRandomCode(12)
             }
             : null,
         blackbox: selectedMissionId === 'blackbox'
@@ -172,7 +172,7 @@ function startDeployment() {
                 caches: [],
                 recovered: 0,
                 uploadSite: null,
-                uploadCode: getRandomCode(4),
+                uploadCode: getRandomCode(6),
                 uploadTimer: 0
             }
             : null
@@ -322,7 +322,7 @@ function generateWorld() {
                 y: 500 + Math.random() * (CONFIG.world.height - 1000),
                 radius: 80,
                 enabled: false,
-                code: getRandomCode(3)
+                code: getRandomCode(6)
             });
         }
     }
@@ -342,7 +342,7 @@ function generateWorld() {
                 y: outpost.y + (Math.random() - 0.5) * 140,
                 radius: 55,
                 recovered: false,
-                code: getRandomCode(3)
+                code: getRandomCode(5)
             });
         }
     }

--- a/main.js
+++ b/main.js
@@ -65,6 +65,7 @@ let missionState = { id: 'exterm', complete: false };
 let missionFx = { launchFlash: 0 };
 let objectiveInput = null;
 let statusFx = { shieldTimer: 0, patrolTimer: 7000 };
+let missionStats = { kills: 0, stratagemsUsed: 0, holesSealed: 0, objectivesCompleted: 0 };
 
 const camera = { x: 0, y: 0 };
 const player = {
@@ -91,6 +92,8 @@ function bindMenuEventHandlers() {
 
     document.getElementById('mission-next-btn').addEventListener('click', showLoadout);
     document.getElementById('deploy-btn').addEventListener('click', startDeployment);
+    const doneBtn = document.getElementById('back-to-menu-btn');
+    if (doneBtn) doneBtn.addEventListener('click', () => window.location.reload());
 }
 
 // UI Navigation
@@ -150,7 +153,7 @@ function startDeployment() {
         extracted: false,
         extraction: {
             x: 0, y: 0, radius: 120, stage: 'LOCKED', defendTimer: 0,
-            code: ['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft']
+            code: getRandomCode(4)
         },
         icbm: selectedMissionId === 'icbm'
             ? {
@@ -159,8 +162,8 @@ function startDeployment() {
                 silo: null,
                 openingTimer: 0,
                 countdown: 0,
-                armCode: ['ArrowUp', 'ArrowRight', 'ArrowDown'],
-                launchCode: ['ArrowUp', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowRight']
+                armCode: getRandomCode(3),
+                launchCode: getRandomCode(6)
             }
             : null,
         blackbox: selectedMissionId === 'blackbox'
@@ -169,11 +172,14 @@ function startDeployment() {
                 caches: [],
                 recovered: 0,
                 uploadSite: null,
-                uploadCode: ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'],
+                uploadCode: getRandomCode(4),
                 uploadTimer: 0
             }
             : null
     };
+
+    missionStats = { kills: 0, stratagemsUsed: 0, holesSealed: 0, objectivesCompleted: 0 };
+    document.getElementById('mission-complete-screen').classList.add('hidden');
 
     // Reset core loadout state on each deployment.
     player.primaryWeapon = 'liberator';
@@ -193,6 +199,26 @@ function startDeployment() {
 }
 
 function getKeyChar(k) { return { 'ArrowUp':'↑', 'ArrowDown':'↓', 'ArrowLeft':'←', 'ArrowRight':'→' }[k] || k; }
+
+function getRandomCode(length) {
+    const arrows = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+    return Array.from({ length }, () => arrows[Math.floor(Math.random() * arrows.length)]);
+}
+
+function getMissionLabel() {
+    return missionState.id === 'icbm' ? 'ICBM LAUNCH' : missionState.id === 'blackbox' ? 'BLACK BOX RETRIEVAL' : 'EXTERMINATE';
+}
+
+function showMissionCompleteScreen() {
+    document.getElementById('mc-mission').innerText = getMissionLabel();
+    document.getElementById('mc-time').innerText = new Date(Date.now() - startTime).toISOString().substr(14, 5);
+    document.getElementById('mc-kills').innerText = missionStats.kills;
+    document.getElementById('mc-objectives').innerText = missionStats.objectivesCompleted;
+    document.getElementById('mc-stratagems').innerText = missionStats.stratagemsUsed;
+    document.getElementById('mc-holes').innerText = missionStats.holesSealed;
+    document.getElementById('mc-score').innerText = score;
+    document.getElementById('mission-complete-screen').classList.remove('hidden');
+}
 
 function getActiveWeaponSlot() { return player.activeSlot; }
 
@@ -221,6 +247,9 @@ function grantSupportWeapon(weaponId) {
 
 function spawnEnemy(kind, x, y, targetBias = 'player') {
     const isBrood = kind === 'BROOD_BRUTE';
+    const towardPlayer = Math.atan2(player.y - y, player.x - x);
+    const patrolHeading = towardPlayer + (Math.random() - 0.5) * 0.9;
+    const patrolDistance = 650 + Math.random() * 220;
     enemies.push({
         x,
         y,
@@ -229,7 +258,8 @@ function spawnEnemy(kind, x, y, targetBias = 'player') {
         damage: isBrood ? 0.7 : 0.3,
         kind,
         state: targetBias === 'patrol' ? 'PATROL' : 'IDLE',
-        patrolTarget: { x: player.x + (Math.random() - 0.5) * 180, y: player.y + (Math.random() - 0.5) * 180 },
+        patrolHeading,
+        patrolTarget: { x: x + Math.cos(patrolHeading) * patrolDistance, y: y + Math.sin(patrolHeading) * patrolDistance },
         detectionMeter: 0,
         angle: 0
     });
@@ -292,7 +322,7 @@ function generateWorld() {
                 y: 500 + Math.random() * (CONFIG.world.height - 1000),
                 radius: 80,
                 enabled: false,
-                code: i === 0 ? ['ArrowUp', 'ArrowLeft', 'ArrowDown'] : ['ArrowRight', 'ArrowDown', 'ArrowLeft']
+                code: getRandomCode(3)
             });
         }
     }
@@ -312,7 +342,7 @@ function generateWorld() {
                 y: outpost.y + (Math.random() - 0.5) * 140,
                 radius: 55,
                 recovered: false,
-                code: ['ArrowUp', 'ArrowRight', 'ArrowDown']
+                code: getRandomCode(3)
             });
         }
     }
@@ -598,10 +628,16 @@ function updateEnemies(delta) {
             e.angle = angle;
             e.x += Math.cos(angle) * (e.speed * 0.8);
             e.y += Math.sin(angle) * (e.speed * 0.8);
-            if (Math.hypot(e.patrolTarget.x - e.x, e.patrolTarget.y - e.y) < 40) e.patrolTarget = { x: player.x + (Math.random() - 0.5) * 220, y: player.y + (Math.random() - 0.5) * 220 };
-            if (dist < 520) e.state = 'CHASE';
+            if (Math.hypot(e.patrolTarget.x - e.x, e.patrolTarget.y - e.y) < 40) {
+                e.patrolHeading += (Math.random() - 0.5) * 0.45;
+                e.patrolTarget = {
+                    x: e.x + Math.cos(e.patrolHeading) * (420 + Math.random() * 280),
+                    y: e.y + Math.sin(e.patrolHeading) * (420 + Math.random() * 280)
+                };
+            }
+            if (dist < 364) e.state = 'CHASE';
         } else if (e.state === 'IDLE') {
-            if (dist < 450) { e.detectionMeter += delta * 0.002; if(e.detectionMeter >= 1) e.state = 'CHASE'; }
+            if (dist < 315) { e.detectionMeter += delta * 0.002; if(e.detectionMeter >= 1) e.state = 'CHASE'; }
         } else {
             const angle = Math.atan2(player.y-e.y, player.x-e.x);
             e.angle = angle;
@@ -612,7 +648,7 @@ function updateEnemies(delta) {
             }
             else { player.health -= e.damage || 0.3; }
         }
-        if (e.health <= 0) { enemies.splice(i, 1); score += 50; spawnParticles(e.x, e.y, '#22c55e', 8); }
+        if (e.health <= 0) { enemies.splice(i, 1); score += 50; missionStats.kills += 1; spawnParticles(e.x, e.y, '#22c55e', 8); }
     });
 
 
@@ -818,6 +854,8 @@ function updateMission(delta) {
         if (ex.stage === 'READY' && Math.hypot(player.x - ex.x, player.y - ex.y) < ex.radius) {
             missionState.extracted = true;
             score += 2000;
+            gameState = 'MISSION_COMPLETE';
+            showMissionCompleteScreen();
         }
     }
 }
@@ -826,7 +864,15 @@ function explode(x, y, radius, damage) {
     spawnParticles(x, y, '#ff8800', 30);
     enemies.forEach(e => { if(Math.hypot(e.x-x, e.y-y) < radius) e.health -= damage; });
 
-    bugHoles.forEach(bh => { if(bh.health > 0 && Math.hypot(bh.x-x, bh.y-y) < radius) { bh.health -= damage; if(bh.health <= 0) score += 500; } });
+    bugHoles.forEach(bh => {
+        if (bh.health > 0 && Math.hypot(bh.x - x, bh.y - y) < radius) {
+            bh.health -= damage;
+            if (bh.health <= 0) {
+                score += 500;
+                missionStats.holesSealed += 1;
+            }
+        }
+    });
     if (Math.hypot(player.x-x, player.y-y) < radius) player.health -= statusFx.shieldTimer > 0 ? damage * 0.01 : damage * 0.05;
 }
 
@@ -919,6 +965,31 @@ function draw() {
             ctx.fillText('ICBM SILO', obj.x, obj.y - obj.radius - 28);
         }
     });
+
+    // Black Box mission objectives are rendered in-world for better readability.
+    if (missionState.id === 'blackbox' && missionState.blackbox) {
+        const bb = missionState.blackbox;
+        bb.caches.forEach((cache, idx) => {
+            if (!cache.recovered) {
+                ctx.fillStyle = '#facc15';
+                ctx.fillRect(cache.x - 14, cache.y - 14, 28, 28);
+                ctx.fillStyle = '#111827';
+                ctx.font = 'bold 10px monospace';
+                ctx.textAlign = 'center';
+                ctx.fillText(`CORE ${idx + 1}`, cache.x, cache.y + 4);
+            }
+        });
+
+        ctx.strokeStyle = bb.stage === 'UPLOADING' ? '#22d3ee' : '#38bdf8';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.arc(bb.uploadSite.x, bb.uploadSite.y, bb.uploadSite.radius, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.lineWidth = 1;
+        ctx.fillStyle = '#e0f2fe';
+        ctx.font = 'bold 11px monospace';
+        ctx.fillText('UPLINK', bb.uploadSite.x, bb.uploadSite.y - bb.uploadSite.radius - 12);
+    }
     
     const ex = missionState.extraction;
     if (missionState.complete && ex && !missionState.extracted) {
@@ -1166,6 +1237,7 @@ function checkSequence(key) {
                 impacted: false, called: false
             });
             cooldowns[match.id] = match.cooldown;
+            missionStats.stratagemsUsed += 1;
             currentSequence = [];
             sequenceTarget = null;
             document.getElementById('seq-title').innerText = 'INPUTTING...';
@@ -1186,6 +1258,7 @@ function checkSequence(key) {
 
         if (currentSequence.length === objectiveInput.code.length) {
             objectiveInput.onComplete();
+            missionStats.objectivesCompleted += 1;
             objectiveInput = null;
             currentSequence = [];
             sequenceTarget = null;


### PR DESCRIPTION
### Motivation
- Make encounters more dynamic by spawning enemy patrols from outposts/edges that intermittently move toward the player. 
- Expand gameplay variety with a new objective-driven mission type beyond the existing bug-hole / ICBM flows. 
- Provide more strategic options and deeper combat by adding multiple new stratagems and a two-slot weapon/loadout model. 
- Replace random circle obstacles with coherent terrain features for clearer navigation and cover while fixing a few gameplay rough edges.

### Description
- Added an entire new mission: Black Box Retrieval, including mission selection UI, cache placement on outposts, an uplink site with input code, timed upload stage, and extraction unlock logic (files modified: `index.html`, `main.js`).
- Implemented enemy patrol waves that spawn periodically from active outposts or map edges and enter a PATROL → CHASE lifecycle towards the player; added `spawnEnemy` helper and patrol state handling.
- Added 5+ new stratagems and effects: `orbital_gas`, `railcannon`, `cluster_bomb`, `shield_relay`, and `autocannon` support pod, and hooked their impact effects (gas/cluster patterns, shield buff, support pod spawn, etc.).
- Overhauled obstacle generation to produce ridge-like polygon rock formations (connected clusters) instead of uniform circles and updated rendering to use obstacle `points` for nicer visuals.
- Reworked the weapon/loadout system to support primary/support slots with per-slot loaded ammo, reserve magazines, manual switching (`1` / `2`), disposable support behavior, and magazine-aware reloads; added HUD text for reserves, ammo, grenade cooldown and reload state.
- Misc: implemented support-pod pickup flow (grants support weapon and mags), shield relay status effect that reduces player damage, and several small helper functions and comments to clarify new systems.

### Testing
- `node --check main.js` was executed and reported no syntax errors (success).
- Hosted the app locally with `python -m http.server 4173` to exercise the UI, which started successfully but automated screenshot attempts failed due to browser/runtime issues in this environment (Chromium crashed with SIGSEGV and Firefox returned `NS_ERROR_NET_RESET`).
- Manual static verification of changed files (`index.html`, `main.js`) and light runtime checks were performed in the sandbox to ensure no immediate runtime syntax problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698def21e700832caea7757b9013cef2)